### PR TITLE
Fixed issue: A large gap between 'Tools' and 'About Us' in navbar #7350

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -45,7 +45,7 @@
           </div>
         </li>
 
-        <li class="nav-item dropdown" style="min-width:80px;">
+        <li class="nav-item dropdown" style="min-width:50px;">
           <a class="nav-link" data-toggle="dropdown" href="#">
             <%= translate('Tools') %>
           </a>


### PR DESCRIPTION
A large gap between 'Tools' and 'About Us' in navbar #7350. Changed 80px to 50px to reduce the space present between 'Tools' and 'About us'.

Fixes #7350(<=== Add issue number here)

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [ ] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [ ] code is in uniquely-named feature branch and has no merge conflicts 📁
* [ ] screenshots/GIFs are attached 📎 in case of UI updation
* [ ] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
